### PR TITLE
fix crash when trying to decode garbage value

### DIFF
--- a/Sources/ReceiptDecoder/DERDecoder.swift
+++ b/Sources/ReceiptDecoder/DERDecoder.swift
@@ -304,7 +304,12 @@ extension DERDecoder {
                         let bigComp = UInt64(component) << (8*offset)
                         result |= bigComp
                     }
-                    self.value = Int(result.littleEndian)
+                    if let value = Int(exactly: result.littleEndian) {
+                        self.value = value
+                    } else {
+                        let debug = "Lenght cannot be represented with an Int"
+                        throw DecodingError.dataCorrupted(.init(debugDescription: debug))
+                    }
                 }
             }
         }


### PR DESCRIPTION
fix crash when trying to decode garbage value which generate a node length that cannot be represented on an Int